### PR TITLE
Remove parent::boot() in the ServiceProvider

### DIFF
--- a/src/Providers/TransfererServiceProvider.php
+++ b/src/Providers/TransfererServiceProvider.php
@@ -64,7 +64,6 @@ class TransfererServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        parent::boot();
     }
 
     /**


### PR DESCRIPTION
parent::boot() was allowed by the following 'boot hack' but Laravel 5.3 doesn't allow that.

https://github.com/illuminate/support/commit/e68a70770be3042e593ab3ef83c12451ea73b004