### PR TITLE
Use brackets instead of parentheses to get a component in the container.

### DIFF
--- a/src/Providers/TransfererServiceProvider.php
+++ b/src/Providers/TransfererServiceProvider.php
@@ -26,19 +26,19 @@ class TransfererServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('scp-transfer', function ($app) {
-            $scpTransfer = (new ScpTransfer())->setLogger($app('log'));
+            $scpTransfer = (new ScpTransfer())->setLogger($app['log']);
 
             return $scpTransfer;
         });
 
         $this->app->singleton('rsync-transfer', function ($app) {
-            $rsyncTransfer = (new RsyncTransfer())->setLogger($app('log'));
+            $rsyncTransfer = (new RsyncTransfer())->setLogger($app['log']);
 
             return $rsyncTransfer;
         });
 
         $this->app->singleton('rsync-daemon', function ($app) {
-            $rsyncTransfer = (new RsyncDaemon())->setLogger($app('log'));
+            $rsyncTransfer = (new RsyncDaemon())->setLogger($app['log']);
 
             return $rsyncTransfer;
         });


### PR DESCRIPTION
I'm not sure why it was working but parentheses didn't work with Laravel 5.3.26 at least.