### PR TITLE
Update service provider to remove use of 'share'

### DIFF
--- a/src/Providers/TransfererServiceProvider.php
+++ b/src/Providers/TransfererServiceProvider.php
@@ -45,11 +45,11 @@ class TransfererServiceProvider extends ServiceProvider
 
         $this->app->alias('scp-transfer', ScpTransfer::class);
 
-        $this->app['command.scp'] = $this->app->share(function ($app) {
+        $this->app->singleton('command.scp', function ($app) {
             return new Scp($app['scp-transfer']);
         });
 
-        $this->app['command.rsync'] = $this->app->share(function ($app) {
+        $this->app->singleton('command.rsync', function ($app) {
             return new Rsync($app['rsync-transfer']);
         });
 


### PR DESCRIPTION
The 'share' method has been removed from the container since Laravel 5.4.
https://laravel.com/docs/5.4/upgrade